### PR TITLE
セッション毎に処理を分離させる

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 #!/bin/python3
 
-from flask import Flask, render_template, make_response, redirect, request
+from flask import Flask, render_template, make_response, redirect, request, url_for
 from dotenv import load_dotenv
 from app.certificate_verifier import CertificateVerifier
 import os
@@ -32,7 +32,7 @@ def exec():
 		work_dir = '/tmp/' + session_id + '/'
 	except Exception as e:
 		print(e)
-		return redirect('/' + env)
+		return redirect(url_for('lambda_handler'))
 
 	if uploadfile(work_dir, 'cert') == 0:
 		return render_template('layout.html', message="ERROR: Certificate not selected", env=env)

--- a/main.py
+++ b/main.py
@@ -29,16 +29,13 @@ def exec():
 	session_id = get_session_id()
 	work_dir = '/tmp/' + session_id + '/'
 
-	uploadfile(work_dir, 'cert')
-	if os.path.getsize(work_dir + 'cert.pem') == 0:
+	if uploadfile(work_dir, 'cert') == 0:
 		return render_template('layout.html', message="ERROR: Certificate not selected", env=env)
 
-	uploadfile(work_dir, 'privkey')
-	if os.path.getsize(work_dir + 'privkey.pem') == 0:
+	if uploadfile(work_dir, 'privkey') == 0:
 		return render_template('layout.html', message="ERROR: Private Key not selected", env=env)
 	
-	uploadfile(work_dir, 'chain')
-	if os.path.getsize(work_dir + 'chain.pem') == 0:
+	if uploadfile(work_dir, 'chain') == 0:
 		return render_template('layout.html', message="ERROR: Intermediate Certificate not selected", env=env)
 
 	cv = CertificateVerifier(work_dir + 'cert.pem', work_dir + 'privkey.pem', work_dir + 'chain.pem')
@@ -60,12 +57,14 @@ def uploadfile(work_dir, type):
 
 	Returns
 	-------
-	None
+	os.path.getsize(work_dir + type + '.pem'): bool
 	"""
 	os.makedirs(work_dir, exist_ok=True)
 
 	file = flask.request.files[type]
 	file.save(work_dir + type + '.pem')
+
+	return os.path.getsize(work_dir + type + '.pem')
 
 def get_session_id():
 	"""

--- a/main.py
+++ b/main.py
@@ -18,9 +18,9 @@ env = os.getenv('ENV')
 def lambda_handler(event=None, context=None):
 	max_age_sec = 300
 	expires = int(datetime.datetime.now().timestamp()) + max_age_sec
-	resp = make_response(render_template('layout.html', env=env))
 	session_id = os.urandom(24).hex()
 	session_info = {'id':session_id}
+	resp = make_response(render_template('layout.html', env=env))
 	resp.set_cookie('id', value=json.dumps(session_info), expires=expires)
 	return resp
 

--- a/main.py
+++ b/main.py
@@ -3,9 +3,12 @@
 from flask import Flask, render_template
 from dotenv import load_dotenv
 from app.certificate_verifier import CertificateVerifier
+from flask import make_response
 import flask
 import os
 import glob
+import datetime
+import json
 
 app = Flask(__name__)
 load_dotenv(override=True)
@@ -13,7 +16,13 @@ env = os.getenv('ENV')
 
 @app.route('/')
 def lambda_handler(event=None, context=None):
-	return render_template('layout.html', env=env)
+	max_age_sec = 300
+	expires = int(datetime.datetime.now().timestamp()) + max_age_sec
+	resp = make_response(render_template('layout.html', env=env))
+	session_id = os.urandom(24).hex()
+	session_info = {'id':session_id}
+	resp.set_cookie('id', value=json.dumps(session_info), expires=expires)
+	return resp
 
 @app.route('/exec', methods=['POST'])
 def exec():

--- a/main.py
+++ b/main.py
@@ -1,9 +1,8 @@
 #!/bin/python3
 
-from flask import Flask, render_template, make_response
+from flask import Flask, render_template, make_response, redirect, request
 from dotenv import load_dotenv
 from app.certificate_verifier import CertificateVerifier
-import flask
 import os
 import glob
 import datetime
@@ -28,8 +27,12 @@ def lambda_handler(event=None, context=None):
 @app.route('/exec', methods=['POST'])
 def exec():
 	
-	session_id = get_session_id()
-	work_dir = '/tmp/' + session_id + '/'
+	try:
+		session_id = get_session_id()
+		work_dir = '/tmp/' + session_id + '/'
+	except Exception as e:
+		print(e)
+		return redirect('/')
 
 	if uploadfile(work_dir, 'cert') == 0:
 		return render_template('layout.html', message="ERROR: Certificate not selected", env=env)
@@ -63,7 +66,7 @@ def uploadfile(work_dir, type):
 	"""
 	os.makedirs(work_dir, exist_ok=True)
 
-	file = flask.request.files[type]
+	file = request.files[type]
 	file.save(work_dir + type + '.pem')
 
 	return os.path.getsize(work_dir + type + '.pem')
@@ -80,7 +83,7 @@ def get_session_id():
 	-------
 	session_info['id']: string
 	"""
-	session_info = flask.request.cookies.get('id')
+	session_info = request.cookies.get('id')
 	if session_info is not None:
 		session_info = json.loads(session_info)
 	

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ def exec():
 		work_dir = '/tmp/' + session_id + '/'
 	except Exception as e:
 		print(e)
-		return redirect('/')
+		return redirect('/' + env)
 
 	if uploadfile(work_dir, 'cert') == 0:
 		return render_template('layout.html', message="ERROR: Certificate not selected", env=env)

--- a/main.py
+++ b/main.py
@@ -15,12 +15,14 @@ env = os.getenv('ENV')
 
 @app.route('/')
 def lambda_handler(event=None, context=None):
+
 	max_age_sec = 300
 	expires = int(datetime.datetime.now().timestamp()) + max_age_sec
-	session_id = os.urandom(24).hex()
-	session_info = {'id':session_id}
+
+	session_info = gen_session_info()
 	resp = make_response(render_template('layout.html', env=env))
-	resp.set_cookie('id', value=json.dumps(session_info), expires=expires)
+	resp.set_cookie('id', value=session_info, expires=expires)
+	
 	return resp
 
 @app.route('/exec', methods=['POST'])
@@ -81,7 +83,25 @@ def get_session_id():
 	session_info = flask.request.cookies.get('id')
 	if session_info is not None:
 		session_info = json.loads(session_info)
+	
 	return session_info['id']
+
+def gen_session_info():
+	"""
+	Generate Session Information
+
+	Parameters
+	----------
+	None
+
+	Returns
+	-------
+	json.dumps(session_info): string ( json )
+	"""
+	session_id = os.urandom(24).hex()
+	session_info = {'id':session_id}
+
+	return json.dumps(session_info)
 
 if __name__ == "__main__":
 	app.run(host='0.0.0.0')


### PR DESCRIPTION
## 概要
以下機能を追加します。

・セッション毎に証明書検証の実行ディレクトリを分離させ、他リクエストの影響を受けないようにします。
・1 セッション辺り 5 分間の期限を設け、期限切れの場合はホーム画面にリダイレクトさせます。